### PR TITLE
feat(mkScript): add _appendTable flag for bugfix

### DIFF
--- a/lib/nuenv.nix
+++ b/lib/nuenv.nix
@@ -67,6 +67,7 @@
     { name
     , script
     , bin ? name
+    , _appendTable ? false
     }:
 
     let
@@ -80,9 +81,7 @@
         #!${nu}
 
         ${script}
-
-        {}
-      '';
+      '' + (if _appendTable then "\n{}" else "");
       executable = true;
     };
 }


### PR DESCRIPTION
I'm using nushell v0.79.0 and I think It's not neccesary to add empty table at the end of every script output.