### PR TITLE
Update to nushell 0.87.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,15 +20,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "narHash": "sha256-PEQptwFCVaJ+jLFJgrZll2shQ9VI/7xVhrCYkJo8iIw=",
-        "rev": "4f77ea639305f1de0a14d9d41eef83313360638c",
-        "revCount": 490691,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2305.490691%2Brev-4f77ea639305f1de0a14d9d41eef83313360638c/018a70b5-07f4-7ca0-99a2-f4a0ec0a6e07/source.tar.gz"
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2305.%2A.tar.gz"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
@@ -45,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694139063,
-        "narHash": "sha256-M2dhhe6IzHmS0zQkmnzbcG98jEQGZ4UcS3VcT+rG/Do=",
+        "lastModified": 1701397143,
+        "narHash": "sha256-nYUJxZXwCWWVBYZXPgRxGDuQcZRhKTtD/Jp5Jl+9EWU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "46dbbcaf435b0d22b149684589b9b059f73f4ffc",
+        "rev": "bb71557c93cad40f5921b2342d7fd69f9e6497ab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Nuenv: a Nushell environment for Nix";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; # Provides Nushell v0.81.0
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; # Provides Nushell v0.87.1
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Nuenv: a Nushell environment for Nix";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2305.*.tar.gz"; # Provides Nushell v0.81.0
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; # Provides Nushell v0.81.0
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
             def info [msg: string] { print $"(color "blue" "INFO"): ($msg)" }
             def success [msg: string] { print $"(color "green" $msg)" }
 
-            info $"Hello, NixCon (date now | date format "%Y")!"
+            info $"Hello, NixCon (date now | format date "%Y")!"
             info "So lovely to see everyone today"
             info "Conference status:"
             success "SUCCESS"

--- a/nuenv/bootstrap.nu
+++ b/nuenv/bootstrap.nu
@@ -21,7 +21,7 @@ for file in $attrs.__nu_env {
 
 # Set the PATH so that Nushell itself is discoverable. The PATH will be
 # overwritten later.
-let-env PATH = ($attrs.__nu_nushell | parse "{root}/nu" | get root.0)
+$env.PATH = ($attrs.__nu_nushell | parse "{root}/nu" | get root.0)
 
 # Run the Nushell builder
 nu --commands (open $attrs.__nu_builder)

--- a/nuenv/builder.nu
+++ b/nuenv/builder.nu
@@ -1,6 +1,6 @@
 ## Utility commands
 
-source env.nu
+export use env.nu *
 
 ## Parse the build environment
 
@@ -85,7 +85,7 @@ let packagesPath = (
   | each { |pkg| $"($pkg)/bin" } # Append /bin to each package path
   | str join (char esep)      # Collect into a single colon-separated string
 )
-let-env PATH = $packagesPath
+$env.PATH = $packagesPath
 
 # Set user-supplied environment variables (à la FOO="bar"). Nix supplies this
 # list by removing reserved attributes (name, system, build, src, system, etc.).
@@ -96,13 +96,13 @@ if $numAttrs != 0 {
 
   for attr in $drv.extraAttrs {
     if $nix.debug { item $"(yellow $attr.key) = \"($attr.value)\"" }
-    let-env $attr.key = $attr.value
+    load-env {$attr.key: $attr.value}
   }
 }
 
 # Copy sources into sandbox
 if $nix.debug { info "Copying sources" }
-for src in $drv.src { cp -r $src $nix.sandbox }
+for src in $drv.src { cp -r -f $src $nix.sandbox }
 
 # Set environment variables for all outputs
 if $nix.debug {
@@ -113,7 +113,7 @@ for output in ($drv.outputs) {
   let name = ($output | get key)
   let value = ($output | get value)
   if $nix.debug { item $"(yellow $name) = \"($value)\"" }
-  let-env $name = $value
+  load-env {$name: $value}
 }
 
 ## The realisation process

--- a/nuenv/builder.nu
+++ b/nuenv/builder.nu
@@ -134,14 +134,14 @@ def runPhase [
     # commands are registered. Right now there's a single env file but in
     # principle there could be per-phase scripts.
     do --capture-errors {
-      nu --log-level warn --env-config $nushell.userEnvFile --commands $phase
+      nu --log-level warn --env-config $nushell.userEnvFile --commands $phase | print
 
       let exitCode = $env.LAST_EXIT_CODE
 
       if ($exitCode | into int) != 0 {
         exit $exitCode
       }
-    } | default {} # To prevent `empty list` being displayed (until Nushell fixes this)
+    }
   } else if $nix.debug { info $"Skipping empty (blue $name) phase" }
 }
 

--- a/nuenv/env.nu
+++ b/nuenv/env.nu
@@ -1,32 +1,32 @@
 # Logging
 
-def color [color: string, msg: string] { $"(ansi $color)($msg)(ansi reset)" }
+export def color [color: string, msg: string] { $"(ansi $color)($msg)(ansi reset)" }
 
-def blue [msg: string] { color "blue" $msg }
-def green [msg: string] { color "green" $msg }
-def red [msg: string] { color "red" $msg }
-def purple [msg: string] { color "purple" $msg }
-def yellow [msg: string] { color "yellow" $msg }
+export def blue [msg: string] { color "blue" $msg }
+export def green [msg: string] { color "green" $msg }
+export def red [msg: string] { color "red" $msg }
+export def purple [msg: string] { color "purple" $msg }
+export def yellow [msg: string] { color "yellow" $msg }
 
-def banner [text: string] { print $"(red ">>>") (green $text)" }
-def info [msg: string] { print $"(blue ">") ($msg)" }
-def error [msg: string] { print $"(red "ERROR") ($msg)" }
-def item [msg: string] { print $"(purple "+") ($msg)"}
+export def banner [text: string] { print $"(red ">>>") (green $text)" }
+export def info [msg: string] { print $"(blue ">") ($msg)" }
+export def error [msg: string] { print $"(red "ERROR") ($msg)" }
+export def item [msg: string] { print $"(purple "+") ($msg)"}
 
 # Misc helpers
 
 ## Add an "s" to the end of a word if n is greater than 1
-def plural [n: int] { if $n > 1 { "s" } else { "" } }
+export def plural [n: int] { if $n > 1 { "s" } else { "" } }
 
 ## Convert a Nix Boolean into a Nushell Boolean ("1" = true, "0" = false)
-def envToBool [var: string] {
+export def envToBool [var: string] {
   ($var | into int) == 1
 }
 
 ## Get package root
-def getPkgRoot [path: path] { $path | parse "{root}/bin/{__bin}" | get root.0 }
+export def getPkgRoot [path: path] { $path | parse "{root}/bin/{__bin}" | get root.0 }
 
 ## Get package name fro full store path
-def getPkgName [storeRoot: path, path: path] {
+export def getPkgName [storeRoot: path, path: path] {
   $path | parse $"($storeRoot)/{__hash}-{pkg}" | select pkg | get pkg.0
 }

--- a/nuenv/user-env.nu
+++ b/nuenv/user-env.nu
@@ -22,13 +22,15 @@ def relativePath [
 # Display the <msg> in a pretty way.
 def log [
   msg: string # The message to log.
-] { $"(ansi green)+(ansi reset) ($msg)" }
+] {
+  print $"(ansi green)+(ansi reset) ($msg)"
+}
 
 # Output the error <msg> in a flashy way.
 def err [
   msg: string # The error string to log
 ] {
-  $"(ansi red)ERROR(ansi reset): ($msg)"
+  print $"(ansi red)ERROR(ansi reset): ($msg)"
 }
 
 # Check that <file> exists and throw an error if it doesn't.
@@ -67,7 +69,7 @@ def substituteInPlace [
   --replace (-r): string, # The string to replace in <file>
   --with (-w): string # The replacement for <replace>
 ] {
-  $files | each { |file| substitute $file $file --replace $replace --with $with }
+  for $file in $files { substitute $file $file --replace $replace --with $with }
 }
 
 # Display Nuenv-specific commands.


### PR DESCRIPTION
Great project! Learned quite a bit about nix from it and the talk. Updated this to latest (at the moment) version of nushell to make it more useful to anybody interested and myself. 
Changes:
- Switched nixpkgs flake input to `github:NixOS/nixpkgs/nixos-unstable` (clould not figure out how to do it via flakehub)
- Replaced usages of `let-env` as it is deprecated now.
- Replaced `source` with `use` as it is not really necessary
- Added missing `-f` option when copying sources
- Fixed use of `format date` in example
- Fixed logging inside phases (build phase). Since [this PR](https://github.com/nushell/nushell/pull/8292) nushell no longer prints output of each commands automatically like bash does. Instead it behaves like conventional programming languages (like python in interpreter mode). It prints return value of last operation in repl mode only and anything explicitly printed via `print` command