### PR TITLE
Implement nuenv.writeShellApplication

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,8 @@
               # Provide helper function
               prev.writeTextFile;
 
+            writeShellApplication = final.callPackage ./lib/writeShellApplication.nix { };
+
             # TODO: mkShell
           };
         };
@@ -98,6 +100,35 @@
             # function to use for writing out script (example: pkgs.writeTextFile)
             writeTextFile:
             internalLib.mkNushellScript nushellPkg writeTextFile;
+
+          /*
+            mkNushellScriptApplication creates a nushell script builder
+
+            Type:
+              [string] -> [string] -> package
+
+            Example:
+              let mkNushellScript = mkNushellScript
+                pkgs.nushell
+                pkgs.writeTextFile;
+              let outScript = mkNushellScript
+                "repair-infra.nu"
+                ''
+                  print -e "(ansi red)fixing infrastructure(ansi reset)"
+                  print "dont_crash_anymore=true" | save -a server_config.toml
+                '';
+          */
+          mkNushellScriptApplication =
+            # nushell package to use for script shebang/execution
+            nushellPkg:
+            # function to use for writing out script (example: pkgs.writeTextFile)
+            writeTextFile:
+            # nixpkgs helper functions, e.g. pkgs.lib
+            lib:
+            import ./lib/writeShellApplication.nix {
+              inherit writeTextFile lib;
+              nushell = nushellPkg;
+            };
         };
 
       devShells = forAllSystems ({ pkgs, system }: {

--- a/lib/writeShellApplication.nix
+++ b/lib/writeShellApplication.nix
@@ -1,0 +1,93 @@
+# An analogue to writeShellApplication but for Nushell rather than Bash scripts.
+{ lib
+, nushell
+, writeTextFile
+}:
+
+let
+  # It might be nicer to write a nix function that translates nix expressions directly to nushell
+  # expressions. But since nix and nu both understand json, using that as an intermediary format is
+  # way easier.
+  toNu = v: "(\"${lib.escape ["\"" "\\"] (builtins.toJSON v)}\" | from json)";
+
+  makeBinPathArray = pkgs:
+    let
+      binOutputs = builtins.filter (x: x != null) (map (pkg: lib.getOutput "bin" pkg) pkgs);
+    in
+    map (output: output + "/bin") binOutputs;
+in
+
+{
+  /*
+    The name of the script to write.
+    Type: String
+   */
+  name
+, /*
+  The shell script's text, not including a shebang.
+  Type: String
+   */
+  text
+, /*
+  Inputs to add to the shell script's `$PATH` at runtime.
+  Type: [String|Derivation]
+   */
+  runtimeInputs ? [ ]
+, /*
+  Extra environment variables to set at runtime.
+  Type: AttrSet
+   */
+  runtimeEnv ? null
+, /*
+  `stdenv.mkDerivation`'s `meta` argument.
+  Type: AttrSet
+   */
+  meta ? { }
+, /*
+  The `checkPhase` to run. Defaults to `nu-check`.
+
+  The script path will be given as `$target` in the `checkPhase`.
+
+  Type: String
+   */
+  checkPhase ? null
+, /*
+   Extra arguments to pass to `stdenv.mkDerivation`.
+
+   :::{.caution}
+   Certain derivation attributes are used internally,
+   overriding those could cause problems.
+   :::
+
+   Type: AttrSet
+   */
+  derivationArgs ? { }
+,
+}:
+writeTextFile {
+  inherit name meta derivationArgs;
+  executable = true;
+  destination = "/bin/${name}";
+  allowSubstitutes = true;
+  preferLocalBuild = false;
+  text = ''
+    #!${nushell}/bin/nu
+  '' + lib.optionalString (runtimeEnv != null) ''
+
+    load-env ${toNu runtimeEnv}
+  '' + lib.optionalString (runtimeInputs != [ ]) ''
+
+    $env.PATH = ${toNu (makeBinPathArray runtimeInputs)} ++ $env.PATH
+  '' + ''
+
+    ${text}
+  '';
+
+  checkPhase =
+    if checkPhase == null then ''
+      runHook preCheck
+      ${nushell}/bin/nu --commands "nu-check --debug '$target'"
+      runHook postCheck
+    ''
+    else checkPhase;
+}


### PR DESCRIPTION
Hi Luc! It's been a while! I enjoy reading your posts on nix when I come across them. I fully agree about the benefits of writing scripts in nushell. I was looking around for a nushell equivalent of `writeShellApplication`, and that lead me to your work on nuenv. I saw that you already have an analog of `writeScriptBin`. That's close, but not quite what I had in mind. So I thought I would contribute my own `writeShellApplication` implementation. It works almost just like the version in nixpkgs but of course it uses nushell, and instead of shellcheck it checks scripts with `nu-check`.